### PR TITLE
master < develop

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-FLAGS = -Wall -g -std=gnu99
+FLAGS = -Wall -g -std=gnu99 -O
 DEBUG = -DDEBUG
 BLOOM = ../libbloom
 STATIC_BLOOM = ${BLOOM}/build

--- a/src/generate_keys.c
+++ b/src/generate_keys.c
@@ -22,7 +22,6 @@
 
 #include "keys.h"
 
-static int callback(void *NotUsed, int argc, char **argv, char **azColName);
 
 int main(int argc, char **argv) {
 
@@ -32,21 +31,22 @@ int main(int argc, char **argv) {
     }
 
 
-    clock_t start, end; // times the execution (for fun)
+    clock_t start, end; // times the execution
     start = clock();
     btc_ecc_start();
 
     const btc_chainparams* chain = &btc_chainparams_main; // mainnet
     const long count = strtol(argv[1], NULL, 10); // # of seeds to use
+    const unsigned long generated = count * PRIVATE_KEY_TYPES;
 
-    // array of keys to add to DB, default size is 20% of count
+    // array of keys to add to DB, default size is 20% of generated priv keys
     struct Array update;
-    init_Array(&update, ceil(2 * count * 0.2));
+    init_Array(&update, ceil(generated * 0.2));
 
-    // array of keys that may or may not be in DB, must check.
-    // default size is 1% of count, since bloom filter has error rate of 1%
+    // array of keys that may or may not be in DB, must check. Default size is
+    // 1% of generated priv keys, since the bloom filter has error rate of 1%
     struct Array check;
-    init_Array(&check, ceil(2 * count * 0.01));
+    init_Array(&check, ceil(generated * 0.01));
 
     /** Private Key Bloom Filter
      * 
@@ -107,8 +107,8 @@ int main(int argc, char **argv) {
         keys[1] = back_pad;
 
         // add private keys to bloom filter
-        for (int i = 0; i < PRIVATE_KEY_TYPES; i++) {
-            int exists = bloom_add(&priv_bloom, keys[i], MAX_BUF - 1);
+        for (int j = 0; j < PRIVATE_KEY_TYPES; j++) {
+            int exists = bloom_add(&priv_bloom, keys[j], MAX_BUF - 1);
             if (exists < 0) {
                 fprintf(stderr, "Bloom filter not initialized\n");
                 exit(1);
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
 
             btc_privkey_init(&key);
             btc_pubkey_init(&pubkey);
-            create_pubkey(keys[i], &key, &pubkey); // fills priv & pub keys
+            create_pubkey(keys[j], &key, &pubkey); // fills priv & pub keys
 
             btc_pubkey_getaddr_p2pkh(&pubkey, chain, address_p2pkh);
             btc_pubkey_getaddr_p2sh_p2wpkh(&pubkey, chain, address_p2sh_p2wpkh);
@@ -139,14 +139,14 @@ int main(int argc, char **argv) {
                 perror("malloc");
                 exit(1);
             }
-            fill_key_set(set, keys[i], seed, address_p2pkh,
+            fill_key_set(set, keys[j], seed, address_p2pkh,
                             address_p2sh_p2wpkh, address_p2wpkh);
 
             #ifdef DEBUG
                 char pubkey_hex[sizeout];
                 btc_pubkey_get_hex(&pubkey, pubkey_hex, &sizeout);
 
-                printf("\nPrivate key: %s\n", keys[i]);
+                printf("\nPrivate key: %s\n", keys[j]);
                 printf("Public Key: %s\n", pubkey_hex);
                 printf("P2PKH: %s\n", address_p2pkh);
                 printf("P2SH: %s\n", address_p2sh_p2wpkh);
@@ -169,90 +169,95 @@ int main(int argc, char **argv) {
     }
     end = clock();
 
-    printf("\nTook %f seconds to generate %ld keys\n", ((double) end - start)/CLOCKS_PER_SEC, count * 2);
+    printf("\nTook %f seconds to generate %ld key sets.\n",
+           ((double) end - start)/CLOCKS_PER_SEC, generated);
 
     fclose(fname);
     bloom_save(&priv_bloom, "private_key_filter.b");
-    printf("False Positives: %d\nFalse Positive Rate: %f\n", false_positive_count, ((double) false_positive_count / (2 * count)));
+    printf("Bloom filter caught %d records.\n", false_positive_count);
 
     // create the sql queries
-    // TODO: do the check query first so we can add them to update list before
-    int query_len = 240; // assume one statement is ~240 bytes (can realloc)
-
-    // size of a query * number of queries needed
-    char *update_sql_query = malloc(sizeof(char) * query_len * update.used);
-    if (update_sql_query == NULL) {
-        perror("malloc");
-        exit(1);
-    }
-
-    clock_t build_start = clock();
-
-    if (build_update_query(&update, &update_sql_query, query_len) == 1) {
-        exit(1);
-    }
-
-    end = clock();
-
-    printf("Took %f seconds to build the query!\n", ((double) end - build_start)/CLOCKS_PER_SEC);
-
+    int check_len = 75; // check statement ~75 bytes
+    int update_len = 240; // update statement ~240 bytes
 
     sqlite3 *db;
     char *zErrMsg = 0;
     int rc;
-    clock_t db_write_start = clock();
+
     rc = sqlite3_open("../db/Observer.db", &db);
     if (rc) {
         fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db));
         exit(1);
     }
 
-    rc = sqlite3_exec(db, update_sql_query, callback, 0, &zErrMsg);
-    free(update_sql_query);
+    // update database
+    char *update_sql_query;
+    if (update.used > 0) {
+        if (prepare_query(&update, &update_sql_query, update_len, UPDATE) == 1){
+            fprintf(stderr, "Failed to build query\n");
+            exit(1);
+        }
 
-    if (rc != SQLITE_OK ) {
-        fprintf(stderr, "SQL error: %s\n", zErrMsg);
-        sqlite3_free(zErrMsg);
+        rc = sqlite3_exec(db, update_sql_query, callback, 0, &zErrMsg);
+        free(update_sql_query);
+
+        if (rc != SQLITE_OK ) {
+            fprintf(stderr, "SQL error: %s\n", zErrMsg);
+            sqlite3_free(zErrMsg);
+        } else {
+            printf("Wrote %zu records to the keys table.\n", update.used);
+        }
     }
 
+    free_Array(&update); // no longer need these records
+    // reallocate because we might fill with records that failed bloom filter
+    init_Array(&update, ceil(0.5 * check.used));
 
-    // TODO put the check query first so we can write everything once.
-    // char *check_sql_query = malloc(sizeof(char) * query_len); // 500 bytes to start
-    // // check query
-    // for (int i = 0; i < check.used; i++) {
-    //     char *values = sqlite3_mprintf("SELECT privkey FROM keys WHERE "\
-    //                                    "privkey='%q'; ",
-    //                                    check.array[i]->private);
-    //     if (values == NULL) {
-    //         fprintf(stderr, "Could not allocate memory for insert query.");
-    //         exit(1);
-    //     }
-    //     // check if we need to reallocate the query
-    //     if (strlen(values) + strlen(check_sql_query) >= query_len - 1) {
-    //         check_sql_query = realloc(check_sql_query,
-    //                                    2 * query_len * sizeof(char));
-    //         query_len *= 2;
-    //     }
-    //     strcat(check_sql_query, values);
-    //     sqlite3_free(values);
-    // }
-    sqlite3_close(db);
+    // check database for records
+    char *check_sql_query;
+    if (check.used > 0) {
+        if (prepare_query(&check, &check_sql_query, check_len, CHECK) == 1) {
+            fprintf(stderr, "Failed to build query\n");
+            exit(1);
+        }
 
-    end = clock();
-    printf("Took %f seconds to write the query!\n", ((double) db_write_start - start)/CLOCKS_PER_SEC);
+        struct Array exists; // array of elements that were found in the db
+        init_Array(&exists, ceil(2 * check.used * 0.5)); // TODO: determine best size
 
-    free_Array(&update);
+        rc = sqlite3_exec(db, check_sql_query, callback, &exists, &zErrMsg);
+        if (rc != SQLITE_OK ) {
+            fprintf(stderr, "SQL error: %s\n", zErrMsg);
+            sqlite3_free(zErrMsg);
+        }
+        printf("%zu of the %zu records generated were already stored in the "\
+               "database.\n", exists.used, generated);
+        free(check_sql_query);
+        push_Difference(&exists, &check, &update);
+        free_Array(&exists);
+    }
     free_Array(&check);
 
-    return 0;
-}
+    // add records that had to be checked (if there are any)
+    if (update.used > 0) {
+        if (prepare_query(&update, &update_sql_query, update_len, UPDATE) == 1){
+            fprintf(stderr, "Failed to build query\n");
+            exit(1);
+        }
 
-// TODO rewrite CALLBACK function for our purposes
-static int callback(void *NotUsed, int argc, char **argv, char **azColName) {
-   int i;
-   for(i = 0; i<argc; i++) {
-      printf("%s = %s\n", azColName[i], argv[i] ? argv[i] : "NULL");
-   }
-   printf("\n");
-   return 0;
+        rc = sqlite3_exec(db, update_sql_query, callback, 0, &zErrMsg);
+        free(update_sql_query);
+
+        if (rc != SQLITE_OK ) {
+            fprintf(stderr, "SQL error: %s\n", zErrMsg);
+            sqlite3_free(zErrMsg);
+        } else {
+            printf("Wrote an additional %zu records to the keys table.\n",
+                   update.used);
+        }
+    }
+
+    free_Array(&update);
+    sqlite3_close(db);
+
+    return 0;
 }

--- a/src/generate_keys.c
+++ b/src/generate_keys.c
@@ -177,7 +177,7 @@ int main(int argc, char **argv) {
 
     // create the sql queries
     // TODO: do the check query first so we can add them to update list before
-    int query_len = 500; // assume one statement is ~500 bytes (can realloc)
+    int query_len = 240; // assume one statement is ~240 bytes (can realloc)
 
     // size of a query * number of queries needed
     char *update_sql_query = malloc(sizeof(char) * query_len * update.used);
@@ -186,18 +186,21 @@ int main(int argc, char **argv) {
         exit(1);
     }
 
+    clock_t build_start = clock();
+
     if (build_update_query(&update, &update_sql_query, query_len) == 1) {
         exit(1);
     }
+
     end = clock();
 
-    printf("Took %f seconds to build the query!\n", ((double) end - start)/CLOCKS_PER_SEC);
+    printf("Took %f seconds to build the query!\n", ((double) end - build_start)/CLOCKS_PER_SEC);
 
 
     sqlite3 *db;
     char *zErrMsg = 0;
     int rc;
-
+    clock_t db_write_start = clock();
     rc = sqlite3_open("../db/Observer.db", &db);
     if (rc) {
         fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db));
@@ -236,7 +239,7 @@ int main(int argc, char **argv) {
     sqlite3_close(db);
 
     end = clock();
-    printf("Took %f seconds to complete!\n", ((double) end - start)/CLOCKS_PER_SEC);
+    printf("Took %f seconds to write the query!\n", ((double) db_write_start - start)/CLOCKS_PER_SEC);
 
     free_Array(&update);
     free_Array(&check);

--- a/src/key_funcs.c
+++ b/src/key_funcs.c
@@ -35,11 +35,53 @@ void push_Array(struct Array *key_array, struct key_set *set) {
     key_array->array[key_array->used++] = set; // increment used and add to the array
 }
 
+void push_Difference(struct Array *a, struct Array *b, struct Array *dest) {
+    size_t count = 0;
+    for (int i = 0; i < b->used; i++) {
+        // no more records need to be checked
+        if (count == b->used - a->used) {
+            break;
+        }
+        int found = 0;
+        for (int j = 0; j < a->used; j++) {
+            // compare private keys
+            if (strcmp(b->array[i]->private, a->array[j]->private) == 0) {
+                found = 1;
+                break;
+            }
+        }
+        if (found == 0) {
+            push_Array(dest, b->array[i]);
+            count++;
+        }
+    }
+}
+
 void free_Array(struct Array *key_array) {
     for (int i = 0; i < key_array->used; i++) {
         free(key_array->array[i]);
     }
     free(key_array->array);
+}
+
+int prepare_query(struct Array *arr, char **query, int query_size, int type) {
+    *query = malloc(sizeof(char) * query_size * arr->used);
+
+    if (*query == NULL) {
+        perror("malloc");
+        return 1;
+    }
+
+    if (type == CHECK) {
+        if (build_check_query(arr, query, query_size) == 1) {
+            return 1;
+        }
+    } else if (type == UPDATE) {
+        if (build_update_query(arr, query, query_size) == 1) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 
@@ -48,6 +90,7 @@ int build_update_query(struct Array *update, char **query, int query_size) {
     char *begin = "BEGIN TRANSACTION; ";
     strcpy(*query, begin);
     current_len += strlen(begin);
+
     for (int i = 0; i < update->used; i++) {
         char *values = sqlite3_mprintf("INSERT INTO keys VALUES ('%q', '%q', "\
                                        "'%q', '%q', '%q'); ",
@@ -74,10 +117,55 @@ int build_update_query(struct Array *update, char **query, int query_size) {
         current_len += val_len;
         sqlite3_free(values);
     }
+
     char *commit = "COMMIT;";
     strcat(*query + current_len, commit);
     current_len += strlen(commit);
     (*query)[current_len] = '\0';
+
+    return 0;
+}
+
+int build_check_query(struct Array *check, char **query, int query_size) {
+    size_t current_len = 0;
+    char *begin = "BEGIN TRANSACTION; ";
+    strcpy(*query, begin);
+    current_len += strlen(begin);
+    for (int i = 0; i < check->used; i++) {
+        char *values = sqlite3_mprintf("SELECT * FROM keys WHERE privkey='%q'; ",
+                                       check->array[i]->private);
+
+        if (values == NULL) {
+                fprintf(stderr, "Could not allocate memory for check query.");
+                return 1;
+        }
+        // check if we need to reallocate the query
+        int val_len = strlen(values);
+        if (val_len + current_len >= query_size) {
+            *query = realloc(*query, 2 * query_size * sizeof(char));
+            if (*query == NULL) {
+                perror("realloc");
+                return 1;
+            }
+            query_size *= 2;
+        }
+        memcpy(*query + current_len, values, val_len + 1);
+        current_len += val_len;
+        sqlite3_free(values);
+    }
+    char *commit = "COMMIT;";
+    strcat(*query + current_len, commit);
+    current_len += strlen(commit);
+    (*query)[current_len] = '\0';
+    return 0;
+}
+
+int callback(void *arr, int argc, char **argv, char **columns) {
+    // TODO: we could just store the private key, not the whole key set.
+    // add this key_set to our in_db array
+    struct key_set *keys = malloc(sizeof(struct key_set));
+    fill_key_set(keys, argv[0], argv[1], argv[2], argv[3], argv[4]);
+    push_Array(arr, keys);
     return 0;
 }
 

--- a/src/key_funcs.c
+++ b/src/key_funcs.c
@@ -45,6 +45,9 @@ void free_Array(struct Array *key_array) {
 
 int build_update_query(struct Array *update, char **query, int query_size) {
     size_t current_len = 0; // keep track of length of query string.
+    char *begin = "BEGIN TRANSACTION; ";
+    strcpy(*query, begin);
+    current_len += strlen(begin);
     for (int i = 0; i < update->used; i++) {
         char *values = sqlite3_mprintf("INSERT INTO keys VALUES ('%q', '%q', "\
                                        "'%q', '%q', '%q'); ",
@@ -71,6 +74,9 @@ int build_update_query(struct Array *update, char **query, int query_size) {
         current_len += val_len;
         sqlite3_free(values);
     }
+    char *commit = "COMMIT;";
+    strcat(*query + current_len, commit);
+    current_len += strlen(commit);
     (*query)[current_len] = '\0';
     return 0;
 }

--- a/src/key_funcs.c
+++ b/src/key_funcs.c
@@ -43,8 +43,8 @@ void free_Array(struct Array *key_array) {
 }
 
 
-int build_update_query(struct Array *update, char **query, int query_len) {
-    size_t current_len = 0; // less expensive than strlen
+int build_update_query(struct Array *update, char **query, int query_size) {
+    size_t current_len = 0; // keep track of length of query string.
     for (int i = 0; i < update->used; i++) {
         char *values = sqlite3_mprintf("INSERT INTO keys VALUES ('%q', '%q', "\
                                        "'%q', '%q', '%q'); ",
@@ -59,19 +59,19 @@ int build_update_query(struct Array *update, char **query, int query_len) {
         }
         // check if we need to reallocate the query
         int val_len = strlen(values);
-        if (val_len + current_len >= query_len - 1) {
-            *query = realloc(*query, 2 * query_len * sizeof(char));
+        if (val_len + current_len >= query_size) {
+            *query = realloc(*query, 2 * query_size * sizeof(char));
             if (*query == NULL) {
                 perror("realloc");
                 return 1;
             }
-            query_len *= 2;
+            query_size *= 2;
         }
-
-        strcat(*query, values);
+        memcpy(*query + current_len, values, val_len + 1);
         current_len += val_len;
         sqlite3_free(values);
     }
+    (*query)[current_len] = '\0';
     return 0;
 }
 

--- a/src/key_funcs.c
+++ b/src/key_funcs.c
@@ -44,6 +44,7 @@ void free_Array(struct Array *key_array) {
 
 
 int build_update_query(struct Array *update, char **query, int query_len) {
+    size_t current_len = 0; // less expensive than strlen
     for (int i = 0; i < update->used; i++) {
         char *values = sqlite3_mprintf("INSERT INTO keys VALUES ('%q', '%q', "\
                                        "'%q', '%q', '%q'); ",
@@ -57,7 +58,8 @@ int build_update_query(struct Array *update, char **query, int query_len) {
             return 1;
         }
         // check if we need to reallocate the query
-        if (strlen(values) + strlen(*query) >= query_len - 1) {
+        int val_len = strlen(values);
+        if (val_len + current_len >= query_len - 1) {
             *query = realloc(*query, 2 * query_len * sizeof(char));
             if (*query == NULL) {
                 perror("realloc");
@@ -67,6 +69,7 @@ int build_update_query(struct Array *update, char **query, int query_len) {
         }
 
         strcat(*query, values);
+        current_len += val_len;
         sqlite3_free(values);
     }
     return 0;

--- a/src/keys.h
+++ b/src/keys.h
@@ -6,6 +6,8 @@
 #define SIZEOUT 128
 #define MAX_BUF BTC_ECKEY_PKEY_LENGTH + 1 // add a byte for the null terminator
 #define PRIVATE_KEY_TYPES 2 // # of private keys we generate from a given seed
+#define UPDATE 0
+#define CHECK 1
 
 struct key_set {
     char private[33];
@@ -34,13 +36,29 @@ void init_Array(struct Array *key_array, size_t size);
 */
 void push_Array(struct Array *key_array, struct key_set *set);
 
+/*  Push all elements of b - a to dest.*/
+void push_Difference(struct Array *a, struct Array *b, struct Array *dest);
+
 /* Frees the key_array and all key_sets within it. */
 void free_Array(struct Array *key_array);
 
-/*  Builds the query for adding to the database.
-    Returns 1 if it fails, 0 on succcess.
+/*  Allocates space and calls the appropriate query builder function.
+    Returns 1 if the build failed, 0 if it succeeded.
 */
-int build_update_query(struct Array *update, char **query, int query_len);
+int prepare_query(struct Array *arr, char **query, int query_size, int type);
+
+/*  Builds the query for adding to the database.
+    Returns 1 if it fails, 0 if it succeeds.
+*/
+int build_update_query(struct Array *update, char **query, int query_size);
+
+/*  Builds the query for checking the database for certain records.
+    Returns 1 if it fails, 0 if it succeeds.
+*/
+int build_check_query(struct Array *check, char **query, int query_size);
+
+/*  sqlite3 callback function for checking if a private key is in the db */
+int callback(void *arr, int argc, char **argv, char **columns);
 
 void remove_newline(char *s);
 


### PR DESCRIPTION
generate_keys will write records if they don't exist in the database (even if the bloom filter caught them). This PR also includes optimized query building and read/writes to the database. Run time decreased by about 99.3% due to these changes (22+ min to 8.9 seconds for 200k private keys and an empty db).