### PR TITLE
GEN-10 Switch from sqlite_exec to sqlite_prepare.

### DIFF
--- a/src/key_funcs.c
+++ b/src/key_funcs.c
@@ -179,8 +179,9 @@ void free_Array(struct Array *key_array) {
 
 
 int remove_duplicates(struct Array *src, struct Array *dest) {
-    // TODO: check return value here after merging GEN-6
-    init_Array(dest, (size_t) src->used * 0.5);
+    if (init_Array(dest, (size_t) src->used * 0.5) == 2) {
+        return 1;
+    }
 
     for (int i = 0; i < src->used; i++) {
         // last element


### PR DESCRIPTION
This is more so for consistency and usability than for efficiency. Transaction performance won't change in either direction by much.