### PR TITLE
GEN-13 Speed up `push_Difference()` function

### DIFF
--- a/src/generate_keys.c
+++ b/src/generate_keys.c
@@ -265,7 +265,9 @@ int main(int argc, char **argv) {
         printf("\n%zu of the %d records caught by the bloom filter were "\
         "already stored in the database.\n", exists.used, false_positive_count);
         free(check_sql_query);
-        push_Difference(&exists, &check, &candidates);
+        if (exists.used > 0 && exists.used != check.used){
+            push_Difference(&exists, &check, &candidates);
+        }
         // see the wiki for details on freeing Array structs.
         free_Array(&exists); // <- has references to new key_sets, a valid free
     }

--- a/src/key_funcs.c
+++ b/src/key_funcs.c
@@ -143,9 +143,8 @@ void push_Array(struct Array *key_array, struct key_set *set) {
     key_array->array[key_array->used++] = set; // increment used, add to array
 }
 
-// TODO: If 38 records weren't found, and BF caugth 200k, we do 199,962 * 200,000 = 39,992,400,000 operations
-// try some kind of sorting method to make this faster because this isn't gonna cut it.
-// EDIT: sorting looks like it will take this from n**2 to n * log(n) [~1 mil ops]!!
+// TODO: Currently takes (|A| * |B|) operations -- o(n**2)
+// Changing the algorithm should bring us closer to (|A| + |B|)  -- o(n)
 void push_Difference(struct Array *a, struct Array *b, struct Array *dest) {
     size_t count = 0;
     for (int i = 0; i < b->used; i++) {


### PR DESCRIPTION
`push_Difference()` calculates the difference between 2 `Array:arr`s and stores the result in a third `Array`. Currently, to calculate `A \ B`, `push_Difference()` looks at every element in `B` each time it checks a new element in `A`, making the run time **o(n^2)**. This is really slow, so this PR will bring the run time closer to **o(n)**.

Should resolve issue #13 