### PR TITLE
GEN-3 An on-going effort to add new seed -> priv key methods

### DIFF
--- a/src/key_funcs.c
+++ b/src/key_funcs.c
@@ -6,7 +6,8 @@
 
 
 const priv_func_ptr priv_gen_functions[PRIVATE_KEY_TYPES] = { &front_pad_pkey,
-                                                              &back_pad_pkey/*,
+                                                              &back_pad_pkey,
+                                                              &sha256_pkey/*,
                                                               &your_method */};
 
 int sort_seeds(char *orig, char *sorted) {
@@ -358,17 +359,29 @@ char **seed_to_priv(char *seed, int len) {
 }
 
 
-void front_pad_pkey(char *seed, char *front_pad, int len) {
-    memset(front_pad, '0', (MAX_BUF - 1) - len);
-    front_pad[MAX_BUF - 1 - len] = '\0';
-    strncat(front_pad, seed, len);
+void front_pad_pkey(char *seed, char *buf, int len) {
+    memset(buf, '0', (MAX_BUF - 1) - len);
+    buf[MAX_BUF - 1 - len] = '\0';
+    strncat(buf, seed, len);
 }
 
 
-void back_pad_pkey(char *seed, char *back_pad, int len) {
-    strncpy(back_pad, seed, len);
-    memset(back_pad + len, '0', (MAX_BUF - 1) - len);
-    back_pad[MAX_BUF - 1] = '\0';
+void back_pad_pkey(char *seed, char *buf, int len) {
+    strncpy(buf, seed, len);
+    memset(buf + len, '0', (MAX_BUF - 1) - len);
+    buf[MAX_BUF - 1] = '\0';
+}
+
+
+void sha256_pkey(char *seed, char *buf, int len) {
+    uint256 bin;
+    // populates bin with 256 bit hash of seed
+    sha256_Raw((const unsigned char *) seed, len, bin);
+
+    // translate 256 bit bin array to 64 char hex and save the first 32 chars
+    strncpy(buf, utils_uint8_to_hex((const uint8_t*) bin,
+            BTC_ECKEY_PKEY_LENGTH), BTC_ECKEY_PKEY_LENGTH);
+    buf[MAX_BUF - 1] = '\0';
 }
 
 

--- a/src/keys.h
+++ b/src/keys.h
@@ -1,5 +1,8 @@
 #include <btc.h>
 #include <ecc_key.h>
+#include <sha2.h>
+#include <utils.h>
+
 
 #include <bloom.h>
 
@@ -7,7 +10,7 @@
 
 #define SIZEOUT 128
 #define MAX_BUF BTC_ECKEY_PKEY_LENGTH + 1 // add a byte for the null terminator
-#define PRIVATE_KEY_TYPES 2 // # of private keys we generate from a given seed
+#define PRIVATE_KEY_TYPES 3 // # of private keys we generate from a given seed
 #define UPDATE 0
 #define CHECK 1
 
@@ -146,16 +149,22 @@ void remove_newline(char *s);
 char **seed_to_priv(char *seed, int len);
 
 
-/*  Puts the seed into the string front_pad then front pads it with 0's until
+/*  Puts the seed into the string buf then front pads it with 0's until
     there are 33 characters (including a null terminator).
 */
-void front_pad_pkey(char *seed, char *front_pad, int len);
+void front_pad_pkey(char *seed, char *buf, int len);
 
 
-/*  Puts the seed into the string front_pad then back pads it with 0's until
+/*  Puts the seed into the string buf then back pads it with 0's until
     there are 33 characters (including a null terminator).
 */
-void back_pad_pkey(char *seed, char *back_pad, int len);
+void back_pad_pkey(char *seed, char *buf, int len);
+
+
+/*  Puts the seed through sha256, then stores the first 32 characters of the
+    resulting hex string in buf.
+*/
+void sha256_pkey(char *seed, char *buf, int len);
 
 
 /*  Takes a buffer (private key string), an empty btc_key and empty btc_pubkey 


### PR DESCRIPTION
Padding seeds with 0's is a good start, but for this to potentially find keys we want to mutate seeds in more than 2 ways. Developers of wallet software or other address generators may have had bad key derivation code, and so we could try to mimic their algorithms. Some other methods could be `sha256(sha256(seed))`, `ripemd160(sha256(seed))`, `sha256(front/back padded seed)`, etc.

I think it might also be a good idea to turn 32 character *ascii* private keys into 64 character *hex* private keys and then cut them in half. It's possible that some developers just split their hex keys in half to avoid encoding them differently.