### PR TITLE
SCAN-4 Get used addresses from blockchain.com

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -43,5 +43,7 @@ cd ../src
 pip3 install cython
 echo "Compiling Cython.."
 python3 setup.py build_ext --inplace
-echo "Searching blockchain for new addresses. You can do this via: python3 download.py"
-#python3 download.py
+echo "Loading all used bitcoin addresses..."
+python3 load_addresses.py
+echo "Addresses loaded!"
+# nohup python3 download.py &

--- a/configure.sh
+++ b/configure.sh
@@ -44,14 +44,16 @@ pip3 install cython
 echo "Compiling Cython.."
 python3 setup.py build_ext --inplace
 # if you only care about UTxO, then you can skip this (eventually!)
-echo "Do you want to download all previously used addresses? (y/n):"
+echo "Do you want to download all addresses that have been used in the last ~584,000 blocks? (y/n):"
 read response
 if [ $response = "y" ]
 then
-    echo "Feature coming soon"
-    # download all the files from S3
+    mkdir address_sets
+    echo "Downloading addresses from S3, this will take some time."
+    sh s3_download.sh
     # load the addresses into the database
-    #sh load.sh
-    # echo "Addresses loaded!"
+    echo "Done! Loading addresses into sqlite3."
+    sh load.sh
+    echo "Addresses loaded!"
 else
-    echo "Skipping download."
+    echo "Skipping download. You can do this at a later time, just read over the configure.sh script."

--- a/configure.sh
+++ b/configure.sh
@@ -43,7 +43,15 @@ cd ../src
 pip3 install cython
 echo "Compiling Cython.."
 python3 setup.py build_ext --inplace
-echo "Loading all used bitcoin addresses..."
-python3 load_addresses.py
-echo "Addresses loaded!"
-# nohup python3 download.py &
+# if you only care about UTxO, then you can skip this (eventually!)
+echo "Do you want to download all previously used addresses? (y/n):"
+read response
+if [ $response = "y" ]
+then
+    echo "Feature coming soon"
+    # download all the files from S3
+    # load the addresses into the database
+    #sh load.sh
+    # echo "Addresses loaded!"
+else
+    echo "Skipping download."

--- a/configure.sh
+++ b/configure.sh
@@ -52,8 +52,11 @@ then
     echo "Downloading addresses from S3, this will take some time."
     sh s3_download.sh
     # load the addresses into the database
-    echo "Done! Loading addresses into sqlite3."
-    sh load.sh
-    echo "Addresses loaded!"
+    echo "Done! Loading addresses into sqlite3, this will take a while so it will be run in the background."
+    echo "If at any point you want to quit, just find the process and kill it via"
+    echo "kill -KILL <pid>"
+    echo "For example, ps aux | grep load.sh"
+    echo "Then ps aux | grep load_adresses.py"
+    sh load.sh &
 else
     echo "Skipping download. You can do this at a later time, just read over the configure.sh script."

--- a/src/download.py
+++ b/src/download.py
@@ -1,16 +1,18 @@
 """
-Download and store all bitcoin addresses that have been used.
-For now we'll use the Blockchain.com API, though I'd like to use bitcoind's blocks
-eventually.
+Download and store all bitcoin addresses that have been used since the first 
+block. The script gets the blocks from blockchain.com's api.
 
-Addresses will be stored in Observer's database.
-Once all records have been written, they'll be added to a libbloom bloom filter.
+There are a lot of addresses, and finding them by iterating blocks is pretty 
+slow, so it's a good idea to run this every few thousand blocks.
+
+To speed the process up, addresses.txt stores all the addresses found in the 
+first 550000+ blocks, and will be continuously updated. These are added to the 
+database and progress.b on set up.
 """
 from functions import check_download, get_addresses, update_db, update_progress
 import pickle
 import requests
 import signal
-from urllib3 import exceptions
 
 block = 0
 addresses = set()
@@ -21,15 +23,21 @@ def signal_handler(signal, frame):
     Handles a SIGINT signal caused by ctrl + c.
     When the script is killed, all progress will be saved.
     """
+    print("\nReceived keyboard interupt signal.")
+    save_progress(block, addresses, new_addresses)
+    raise KeyboardInterrupt()
 
-    print("Saving work... last block scanned was {}".format(block))
+def save_progress(block, addresses, new_addresses):
+    """
+    Saves the work we've completed.
+    """
+    print("Saving progress... last block scanned was {}.".format(block))
     update_progress(block, addresses)
     update_db(new_addresses)
-    exit(1)
-
 
 if __name__ == "__main__":
     flag = False
+    # try to load previous progress (if there is any)
     try:
         fname = open("progress.b", "rb")
         progress = pickle.load(fname)
@@ -45,27 +53,31 @@ if __name__ == "__main__":
         addresses = progress['addresses']
         print("Starting at block {}".format(block))
 
-    # we start handling sigint here
+    # we start handling keyboard interrupts here
     signal.signal(signal.SIGINT, signal_handler)
 
-    print("Progress will be saved when you press \"ctrl + c\" or after all "
-        "addresses have been found.")
+    print("You can save and quit by pressing ctrl + c. If an error occurs, your"
+          " progress will be saved. Once the most recent block is found, the"
+          " script will exit.")
 
 
     # make first request, then loop and check response
-    url = "https://blockchain.info/block-height/{}?format=json".format(block)
-    response = requests.get(url)
+    url = "https://blockchain.info/block-height/{}?format=json"
+    response = requests.get(url.format(block))
     try:
         while (response.json()['blocks'][0]['next_block'] != []):
             get_addresses(addresses, new_addresses, response)
             block += 1
-            check_download(block)
-            url = "https://blockchain.info/block-height/{}?format=json".format(block)
-            response = requests.get(url)
-    except exceptions.MaxRetryError as e:
-        print(e)
-        print("Something went wrong. Saving work and exiting!")
+            check_download(block) # prints progress every 100 blocks
+            response = requests.get(url.format(block))
+    except KeyboardInterrupt:
+        exit(1)
+    except:
+        save_progress(block, addresses, new_addresses)
+        print("Your progress has been saved. An error has occured, you should "
+        "run the script again to continue from block {}.".format(block))
+        exit(1)
 
-    update_progress(block, addresses)
-    update_db(new_addresses)
-    print("Finished at block {}".format(block))
+    save_progress(block, addresses, new_addresses)
+    print("Download completed at block {}. This is the most recent block.".format(block))
+    exit(0)

--- a/src/download.py
+++ b/src/download.py
@@ -6,10 +6,11 @@ eventually.
 Addresses will be stored in Observer's database.
 Once all records have been written, they'll be added to a libbloom bloom filter.
 """
-from functions import update_db, get_addresses, check_download, update_progress
+from functions import check_download, get_addresses, update_db, update_progress
 import pickle
 import requests
 import signal
+from urllib3 import exceptions
 
 block = 0
 addresses = set()
@@ -61,7 +62,7 @@ if __name__ == "__main__":
             check_download(block)
             url = "https://blockchain.info/block-height/{}?format=json".format(block)
             response = requests.get(url)
-    except InterruptedError as e:
+    except exceptions.MaxRetryError as e:
         print(e)
         print("Something went wrong. Saving work and exiting!")
 

--- a/src/download.py
+++ b/src/download.py
@@ -1,22 +1,56 @@
-"""
-Download and store all bitcoin addresses that have been used since the first 
-block. The script gets the blocks from blockchain.com's api.
+# This script downloads blocks from blockchain.com's api, then parses these blocks
+# for output bitcoin addresses.
 
-There are a lot of addresses, and finding them by iterating blocks is pretty 
-slow, so it's a good idea to run this every few thousand blocks.
-
-To speed the process up, addresses.txt stores all the addresses found in the 
-first 550000+ blocks, and will be continuously updated. These are added to the 
-database and progress.b on set up.
 """
+You can provide a serialized python object of the following format:
+	
+	obj = {"block": int, "addresses": set()}
+
+to this script if you wish to start downloading at a specific block, or with
+an existing set of addresses.
+
+If you want to start from the first block, either:
+    1. don't use the "-f" flag
+    2. use "-f" and provide a file with the following object {"block": 0, "addresses": set()}
+
+Ex: if I have a file called "progress.b", where "block": 4000 and "addresses"
+is the empty set, I can run
+
+	python3 download.py -f progress.b
+
+to start from block 4000 and add to this set. Once the script finishes (can be by keyboard interrupt)
+all progress will be saved in "progress.b".
+
+Flags are:
+	"-b {int}" the maximum block to iterate to
+	"-d" update the database when finished
+	"-f {file}" the file to read from and write to
+
+Here's another example:
+	"progress.b" has obj = {"block": 500000, "addresses": set()}. If we want to scan
+	50,000 blocks and update the database at the end, we run the following.
+	
+	python3 download.py -f progress.b -b 550000 -d
+
+The script can crash at times for strange reasons, so it's a good idea to call it in a loop.
+A simple bash script could be along the lines of, "while the exit code is 1, run the script with these parameters".
+"""
+# Exit status codes:
+#     - 0 process completed (caught up to most recent block)
+#     - 1 process exited due to error (more blocks can be found)
+#     - 2 process terminated by user (more blocks can be found)
+#     - 3 out of memory
+
+# Running this in parallel on different segments of the blockchain is the best way to get results fast.
+# I recommend you don't scan more than 50,000 blocks per script unless you have A LOT of RAM (+16GB).
+
+
 from functions import check_download, get_addresses, update_db, update_progress
+import getopt
 import pickle
 import requests
-import signal
-
-block = 0
-addresses = set()
-new_addresses = set()
+import signal, struct, sys
+import time
 
 def signal_handler(signal, frame):
     """
@@ -24,60 +58,125 @@ def signal_handler(signal, frame):
     When the script is killed, all progress will be saved.
     """
     print("\nReceived keyboard interupt signal.")
-    save_progress(block, addresses, new_addresses)
     raise KeyboardInterrupt()
 
-def save_progress(block, addresses, new_addresses):
+
+def save_progress(block, addresses, new_addresses, progress_file, with_db):
     """
-    Saves the work we've completed.
+    Saves the work we've completed. If with_db is 1, we will write the 
+    new_addresses to the database.
     """
-    print("Saving progress... last block scanned was {}.".format(block))
-    update_progress(block, addresses)
-    update_db(new_addresses)
+    print("Saving progress... do not close/power off computer until process is"
+          " complete.")
+    update_progress(block, addresses, progress_file)
+    if with_db == 1:
+        print("Updating database...")
+        update_db(new_addresses)
+    else:
+        print("Skipping database update.")
+    print("Progress saved. Last block scanned was {}.".format(block))
+
+def setup():
+    """
+    Parses the command line arguements.
+
+    -d = update database
+    -f {file} where file is the progress file to use
+    -b {block} where block is the max block we will scan to
+    """
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "f:db:")
+    except getopt.GetoptError as err:
+        print(err)
+        print("Usage: python3 {script} -f <progress file> -d")
+        sys.exit(2)
+
+    progress_file = ""
+    with_db = 0 # by default, do not write to the database
+    max_block = -1
+
+    # o is the flag, a is the arguement
+    for o, a in opts:
+        if o == "-f":
+            progress_file = a
+        elif o == "-d":
+            with_db = 1 # update the database when script exits
+        elif o == "-b":
+            max_block = int(a)
+        else:
+            print("Unknown flag {}".format(o))
+    
+    return progress_file, with_db, max_block
+
 
 if __name__ == "__main__":
-    flag = False
+    progress_file, with_db, max_block = setup()
+
     # try to load previous progress (if there is any)
     try:
-        fname = open("progress.b", "rb")
-        progress = pickle.load(fname)
-        fname.close()
+        with open(progress_file, "rb") as f:
+            progress = pickle.load(f)
+            block = progress['block']
+            addresses = progress['addresses']
     except IOError as e:
-        flag = True
-        print("Progress file will be created shortly.")
+        block = 0
+        addresses = set()
+        progress_file = "temp_progress.b"
+    print("Starting at block {}".format(block))
 
-    if flag == True:
-        print("Starting at block 0.")
+    if with_db == 1:
+        print("Database will be updated when new addresses are found.")
     else:
-        block = progress['block']
-        addresses = progress['addresses']
-        print("Starting at block {}".format(block))
+        print("No database operations will be performed.")
+    new_addresses = set()
 
     # we start handling keyboard interrupts here
     signal.signal(signal.SIGINT, signal_handler)
 
-    print("You can save and quit by pressing ctrl + c. If an error occurs, your"
-          " progress will be saved. Once the most recent block is found, the"
+    print("\nYou can save and quit by pressing ctrl + c. If an error occurs, your"
+          " progress will be saved.\nOnce the most recent block is found, the"
           " script will exit.")
-
 
     # make first request, then loop and check response
     url = "https://blockchain.info/block-height/{}?format=json"
     response = requests.get(url.format(block))
     try:
-        while (response.json()['blocks'][0]['next_block'] != []):
+        if (max_block == -1):
+            max_block = block + 50000 # scan 50,000 blocks unless otherwise specified
+        print("Scanning from block {} to {}".format(block, max_block))
+
+        # true if we will iterate until the most recent block
+        new_loop = False
+        for _ in range(max_block - block):
+            # triggers when close to current block, so that we don't try to scan past it
+            if (block >= 584000):
+                new_loop = True
+                break
+
             get_addresses(addresses, new_addresses, response)
             block += 1
             check_download(block) # prints progress every 100 blocks
             response = requests.get(url.format(block))
+
+        if (new_loop):
+            while (response.json()['blocks'][0]['next_block'] != []):
+                get_addresses(addresses, new_addresses, response)
+                block += 1
+                check_download(block) # prints progress every 100 blocks
+                response = requests.get(url.format(block))
+
     except KeyboardInterrupt:
-        exit(1)
+        save_progress(block, addresses, new_addresses, progress_file, with_db)
+        exit(2)
+    except MemoryError as e:
+        print("Out of memory! Will not overwrite (for saftey).")
+        print(e)
+        exit(3)
     except:
-        save_progress(block, addresses, new_addresses)
-        print("Your progress has been saved. An error has occured, you should "
+        print("Exiting because an error has occured, you should "
         "run the script again to continue from block {}.".format(block))
         exit(1)
 
-    save_progress(block, addresses, new_addresses)
+    save_progress(block, addresses, new_addresses, progress_file, with_db)
     print("Download completed at block {}. This is the most recent block.".format(block))
     exit(0)

--- a/src/download.py
+++ b/src/download.py
@@ -6,7 +6,7 @@ eventually.
 Addresses will be stored in Observer's database.
 Once all records have been written, they'll be added to a libbloom bloom filter.
 """
-from functions import update_db, get_addresses, check_download
+from functions import update_db, get_addresses, check_download, update_progress
 import pickle
 import requests
 import signal
@@ -26,20 +26,6 @@ def signal_handler(signal, frame):
     update_db(new_addresses)
     exit(1)
 
-def update_progress(block, addresses):
-    """
-    block [int]: the latest block we've scanned
-    addresses [set]: the current set of unique addresses
-
-    Serialize the current block and address set for later use.
-    """
-    try:
-        fname = open("progress.b", "wb")
-        obj = {'block': block, 'addresses': addresses}
-        pickle.dump(obj, fname)
-        fname.close()
-    except IOError as e:
-        print(e)
 
 if __name__ == "__main__":
     flag = False

--- a/src/functions.pyx
+++ b/src/functions.pyx
@@ -1,5 +1,7 @@
-import sqlite3
+import pickle
 import requests
+import sqlite3
+
 cpdef update_db(set new_addresses):
     db = "../db/observer.db"
     try:
@@ -35,3 +37,18 @@ cpdef get_addresses(set addresses, set new_addresses, response):
 cpdef check_download(int block):
     if block % 100 == 0:
         print("Downloaded block {}".format(block))
+
+cpdef update_progress(int block, set addresses):
+    """
+    block [int]: the latest block we've scanned
+    addresses [set]: the current set of unique addresses
+
+    Serialize the current block and address set for later use.
+    """
+    try:
+        fname = open("progress.b", "wb")
+        obj = {'block': block, 'addresses': addresses}
+        pickle.dump(obj, fname)
+        fname.close()
+    except IOError as e:
+        print(e)

--- a/src/functions.pyx
+++ b/src/functions.pyx
@@ -23,22 +23,24 @@ cpdef update_db(set new_addresses):
 
 
 cpdef get_addresses(set addresses, set new_addresses, response):
+    cdef list transactions = response.json()['blocks'][0]['tx']
     cdef dict i
     cdef dict j
-    for i in response.json()['blocks'][0]['tx']:
+    cdef str candidate
+
+    for i in transactions:
         for j in i['out']:
             if 'addr' in j:
-                # we could check if in set then try to add to db here
-                if j['addr'] not in addresses:
-                    new_addresses.add(j['addr'])
-                    addresses.add(j['addr'])
-
+                candidate = j['addr']
+                if candidate not in addresses:
+                    new_addresses.add(candidate)
+                    addresses.add(candidate)
 
 cpdef check_download(int block):
     if block % 100 == 0:
         print("Downloaded block {}".format(block))
 
-cpdef update_progress(int block, set addresses):
+cpdef update_progress(int block, set addresses, str progress):
     """
     block [int]: the latest block we've scanned
     addresses [set]: the current set of unique addresses
@@ -46,9 +48,9 @@ cpdef update_progress(int block, set addresses):
     Serialize the current block and address set for later use.
     """
     try:
-        fname = open("progress.b", "wb")
+        fname = open(progress, "wb")
         obj = {'block': block, 'addresses': addresses}
-        pickle.dump(obj, fname)
+        pickle.dump(obj, fname, pickle.HIGHEST_PROTOCOL)
         fname.close()
     except IOError as e:
         print(e)

--- a/src/load.sh
+++ b/src/load.sh
@@ -1,3 +1,3 @@
-for i in storage/*; do
+for i in address_sets/*; do
     python3 load_addresses.py -f $i
 done

--- a/src/load.sh
+++ b/src/load.sh
@@ -1,0 +1,3 @@
+for i in storage/*; do
+    python3 load_addresses.py -f $i
+done

--- a/src/load_addresses.py
+++ b/src/load_addresses.py
@@ -8,7 +8,7 @@
     have been found on the blockchain. Storing them here means you don't have to
     search the blockchain for all the addresses that have ever been used.
 """
-from functions import update_progress
+from functions import update_db, update_progress
 import os
 import pickle
 
@@ -17,8 +17,10 @@ try:
         block = int(f.readline())
         addresses = set()
         for i in f.readlines():
+            i = i[:-1] # removes newline
             addresses.add(i)
         update_progress(block, addresses)
+        update_db(addresses)
         os.remove("addresses.txt")
-except:
-    print("Something went wrong.")
+except IOError as e:
+    print(e)

--- a/src/load_addresses.py
+++ b/src/load_addresses.py
@@ -1,0 +1,24 @@
+""" This script takes all the records in addresses.txt and stores them in binary
+    so that the download.py script can store them in Observers database.
+
+    This script should only be ran once. After completion we can probably delete
+    addresses.txt to free up some space, since address info is in progress.b
+
+    The addresses stored in addresses.txt are all unique bitcoin addresses that
+    have been found on the blockchain. Storing them here means you don't have to
+    search the blockchain for all the addresses that have ever been used.
+"""
+from functions import update_progress
+import os
+import pickle
+
+try:
+    with open("addresses.txt", "r") as f:
+        block = int(f.readline())
+        addresses = set()
+        for i in f.readlines():
+            addresses.add(i)
+        update_progress(block, addresses)
+        os.remove("addresses.txt")
+except:
+    print("Something went wrong.")

--- a/src/load_addresses.py
+++ b/src/load_addresses.py
@@ -14,7 +14,7 @@ def setup():
     -f {file} where file is the progress file to use
     """
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "f:db:")
+        opts, args = getopt.getopt(sys.argv[1:], "f:")
     except getopt.GetoptError as err:
         print(err)
         print("Usage: python3 load_addresses.py -f <progress file>")
@@ -41,10 +41,16 @@ try:
     print("Loading addresses from {}".format(progress_file))
     with open(progress_file, "rb") as f:
         data = pickle.load(f)
-        addresses = f['addresses']
+        count = data["count"]
+        addresses = data["addresses"]
+        print("Found {} addresses in {}.".format(count, progress_file))
         print("Updating database, this may take some time.")
         update_db(addresses)
-        print("Upadte complete. Removing {}".format(progress_file))
-        # os.remove(progress_file)
+        print("Update complete. Removing {}".format(progress_file))
+        os.remove(progress_file)
 except IOError as e:
     print(e)
+except:
+    print("Something went wrong. You should re-run the script using the current file.")
+finally:
+    print("Exiting.")

--- a/src/s3_download.sh
+++ b/src/s3_download.sh
@@ -1,0 +1,26 @@
+a=4
+b=4
+c=5
+d=8
+e=7
+f=5
+
+get="wget -P address_sets_test https://observer-test-bucket.s3.amazonaws.com/address_sets/"
+for ((i=0;i<=a;i++)); do
+    $get"a_$i.b"
+done;
+for ((i=0;i<=b;i++)); do
+    $get"b_$i.b"
+done;
+for ((i=0;i<=c;i++)); do
+    $get"c_$i.b"
+done;
+for ((i=0;i<=d;i++)); do
+    $get"d_$i.b"
+done;
+for ((i=0;i<=e;i++)); do
+    $get"e_$i.b"
+done;
+for ((i=0;i<=f;i++)); do
+    $get"f_$i.b"
+done;


### PR DESCRIPTION
Instead of downloading each block and saving all the new addresses, we can store most of them in the repo and only download a small subset of the new addresses.

Say we have all the addresses (unique) used in the first 580,000 blocks, if the repo is cloned at block 600,000 (*about 138 days later*), then the user only has to parse 20,000 blocks (rather than 600,000).

Addresses are saved as a textfile instead of binary for portability; after they've been loaded into binary on the users machine, the textfile is removed to save space.