### PR TITLE
GEN-18 Create and populate a "generated addresses" bloom filter.

### DIFF
--- a/src/keys.h
+++ b/src/keys.h
@@ -59,17 +59,12 @@ int sort_seeds(char *orig, char *sorted);
 size_t get_record_count(sqlite3 *db);
 
 
-/*  Reset the private bloom filter, make it larger, and refill it with the records
+/*  Reset the bloom filters, resize them, and refill them with the records
     from the database. Returns 0 on success, 1 on failure.
 */
-int resize_private_bloom(struct bloom *filter, sqlite3 *db,
-                         unsigned long count);
+int resize_bloom_filters(struct bloom *private_filter, struct bloom *addr_filter,
+                         sqlite3 *db, unsigned long count);
 
-/*  Reset the addresses bloom filter, make it larger, and refill it with the
-    records from the database. Returns 0 on success, 1 on failure.
-*/
-int resize_address_bloom(struct bloom *filter, sqlite3 *db,
-                        unsigned long count);
 
 /*  Fill the key_set set with the provided string arguements.
     Returns 0 if it succeeds and 1 if it fails.

--- a/src/keys.h
+++ b/src/keys.h
@@ -59,12 +59,17 @@ int sort_seeds(char *orig, char *sorted);
 size_t get_record_count(sqlite3 *db);
 
 
-/*  Reset the bloom filter, make it larger, and refill it with the records from
-    the database. Returns 0 on success, 1 on failure.
+/*  Reset the private bloom filter, make it larger, and refill it with the records
+    from the database. Returns 0 on success, 1 on failure.
 */
 int resize_private_bloom(struct bloom *filter, sqlite3 *db,
                          unsigned long count);
 
+/*  Reset the addresses bloom filter, make it larger, and refill it with the
+    records from the database. Returns 0 on success, 1 on failure.
+*/
+int resize_address_bloom(struct bloom *filter, sqlite3 *db,
+                        unsigned long count);
 
 /*  Fill the key_set set with the provided string arguements.
     Returns 0 if it succeeds and 1 if it fails.


### PR DESCRIPTION
### Purpose
We need a bloom filter of all our generated addresses so we can check if mempool transaction outputs are in our database. This PR adds a new bloom filter called `generated_addresses_filter.b`, which stores all the addresses we generate. It can be dynamically resized just like the `private_key_filter.b`. 
### Bug fix
Additionally, I discovered and fixed a small bug (which hasn't affected anything so far). We were creating filters with `count` entries, where `count` is the number of seeds to use. This is wrong, we expect the filter to be at least `count * PRIVATE_KEY_TYPES` entries large, where `PRIVATE_KEY_TYPES` is the number of private keys we generate from any given seed. 

Now we just use `generated`, which is a variable that already existed.

### Things to consider
I think it's unnecessary to create a whole new function for resizing the `generated_addresses_filter.b`, it's almost identical, we could probably do this in the same function that handles the other filter.