### PR TITLE
SCAN-18 Create new struct "output" and replace current outputs array in transaction struct

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -369,8 +369,8 @@ int main() {
             if (transaction_buf != NULL) {
                 /* 4 cases:
                     1. Partial write & empty buffer
-                    3. Complete write & non-empty buffer (...)
                     2. Partial write & non-empty buffer (prev msg was partial)
+                    3. Complete write & non-empty buffer (...)
                     4. Complete write & empty buffer
                 */
                 if (buffer == NULL) {
@@ -459,7 +459,7 @@ int main() {
                         5. Send the size of the script: sizeof(int)
                         6. Send the script: ^size^
                     */
-                    // step 1. (new)
+                    // step 1
                     if (write(fd[1], &list_size, sizeof(list_size)) == -1) {
                         perror("write");
                         fprintf(stderr, "Failed to write the number of outputs"\
@@ -467,14 +467,12 @@ int main() {
                         exit(1);
                     }
 
-                    // (new)
                     for (int i = 0; i < cur_tx->nOutputs; i++) {
                         // write the positive output
                         if (cur_tx->outputs[i]->positive) {
                             int addr_size =
                                 strlen(cur_tx->outputs[i]->address) + 1;
 
-                            // step 2 (new)
                             if (write(fd[1], &addr_size, sizeof(int)) == -1) {
                                 perror("write");
                                 fprintf(stderr, "Failed to write the address "\
@@ -482,7 +480,6 @@ int main() {
                                 exit(1);
                             }
 
-                            // step 3 (new)
                             if (write(fd[1], cur_tx->outputs[i]->address,
                                       addr_size) == -1) {
                                 perror("write");
@@ -491,7 +488,6 @@ int main() {
                                 exit(1);
                             }
 
-                            // step 4 (new)
                             if (write(fd[1], &(cur_tx->outputs[i]->value),
                                       sizeof(unsigned int)) == -1) {
                                 perror("write");
@@ -503,7 +499,6 @@ int main() {
                             int script_size =
                                 strlen(cur_tx->outputs[i]->script) + 1;
 
-                            // step 5 (new)
                             if (write(fd[1], &script_size, sizeof(int)) == -1) {
                                 perror("write");
                                 fprintf(stderr, "Failed to write the script "\
@@ -511,7 +506,6 @@ int main() {
                                 exit(1);
                             }
 
-                            // step 6 (new)
                             if (write(fd[1], cur_tx->outputs[i]->script,
                                       script_size) == -1) {
                                 perror("write");

--- a/src/reader.c
+++ b/src/reader.c
@@ -7,11 +7,6 @@
 
 #include <bloom.h>
 
-#include <btc.h>
-#include <chainparams.h>
-#include <ecc.h>
-#include <ecc_key.h>
-
 #include <libwebsockets.h>
 
 #ifdef __linux__
@@ -28,30 +23,6 @@ void signal_handler(int signum) {
 }
 
 int main() {
-    btc_ecc_start(); // load libbtc
-    
-    struct bloom address_bloom; // filter of all generated addresses.
-    const char address_filter_file[] = "generated_addresses_filter.b";
-    
-    // load the bloom filter
-    if (access((char *) &address_filter_file, F_OK) != -1) {
-        if (bloom_load(&address_bloom, (char *) &address_filter_file) == 0) {
-            printf("Loaded address filter.\n");
-        } else {
-            printf("Failed to load bloom filter.\n");
-            exit(1);
-        }
-    } else {
-        printf("Could not find filter: %s\n", address_filter_file);
-        printf("You have not generated any addresses.\n");
-        exit(1);
-    }
-
-    // some final counts to show the user
-    int total_transactions_checked = 0;
-    int total_addresses_checked = 0;
-    int positive_hit_count = 0;
-
     // set up the pipe, data flows from parent to child.
     int fd[2];
     pipe(fd);
@@ -62,11 +33,8 @@ int main() {
         exit(1);
     } else if (r == 0) {
 
-        /*  Child process reads transactions from the pipe, and checks if their
-            positive outputs are in our database.
-
-            A positive output is an addresses that came back as "positive" from
-            the bloom filter. I.e, it might be in our database.
+        /*  Child process reads positive outputs from the pipe and checks if
+            the address's corresponding private key is in our database.
         */
 
         if (close(fd[1]) == -1) {
@@ -86,65 +54,52 @@ int main() {
             fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db));
             exit(1);
         }
+        struct output **outputs; // array of pointers to output structs
 
-        char **outputs; // array of pointers to output addresses
         int ntxOut = 0; // the number of output addresses
         int response;
 
-        char *child_transaction;
-        int child_tx_size;
-
         // begin (blocking) loop of reading from the pipe
         // Note: Check the pipe protocol in the parent!
-        while ((response = read(fd[0], &child_tx_size, sizeof(int))) != 0) {
+        while ((response = read(fd[0], &ntxOut, sizeof(int))) != 0) {
             if (response == -1) {
                 perror("read");
                 exit(1);
             }
 
-            child_transaction = malloc(child_tx_size * sizeof(char));
-            if (child_transaction == NULL) {
-                perror("malloc");
-                exit(1);
-            }
-
-            if ((response = read(fd[0], child_transaction, child_tx_size))
-                == -1) {
-                perror("read");
-                exit(1);
-            } else if (response == 0) {
-                fprintf(stdout, "Parent closed the pipe.\n");
-                break;
-            }
-
-            if ((response = read(fd[0], &ntxOut, sizeof(ntxOut))) == -1) {
-                perror("read");
-                exit(1);
-            } else if (response == 0) {
-                fprintf(stdout, "Parent closed the pipe.\n");
-                break;
-            }
-
-            printf("Will check %d record(s).\n", ntxOut);
-            outputs = malloc(sizeof(char *) * ntxOut);
+            outputs = malloc(sizeof(struct output *) * ntxOut);
 
             if (outputs == NULL) {
                 perror("malloc");
                 exit(1);
             }
+
             int addr_size; // # of bytes of incoming address
             int total_addr_size_sum = 0; // sum of length of addresses read
 
-            // read each output address into the outputs array
-            for (int j = 0; j < ntxOut; j++) {
-                // error check response
-                if ((response = read(fd[0], &addr_size, sizeof(addr_size))) ==
-                    -1) {
+            for (int i = 0; i < ntxOut; i++) {
+                int addr_size = 0;
+                int script_size = 0;
+
+                struct output *out = malloc(sizeof(struct output));
+
+                if (out == NULL) {
+                    fprintf(stderr, "Couldn't allocate space for output.\n");
+                    exit(1);
+                }
+                printf("Will check %d record(s).\n", ntxOut);
+
+                outputs[i] = out; // assign this output to the array
+
+                // 2. address size
+                if ((response = read(fd[0], &addr_size, sizeof(int))) == -1) {
                     perror("read");
                     exit(1);
                 } else if (response == 0) {
                     fprintf(stdout, "Parent closed the pipe.\n");
-                    for (int addr = 0; addr < j; addr++) {
+                    for (int addr = 0; addr < i; addr++) {
+                        free(outputs[addr]->address);
+                        free(outputs[addr]->script);
                         free(outputs[addr]);
                     }
                     free(outputs);
@@ -152,32 +107,92 @@ int main() {
                 }
                 // increment but don't count null terminator
                 total_addr_size_sum = total_addr_size_sum + addr_size - 1;
-                // allocate space for the incoming address
-                outputs[j] = malloc(addr_size * sizeof(char));
 
-                if (outputs[j] == NULL) {
+                out->address = malloc(sizeof(char) * addr_size);
+                if (out->address == NULL) {
                     perror("malloc");
                     exit(1);
                 }
 
-                // store the address directly in the array
-                // error check response
-                if ((response = read(fd[0], outputs[j], addr_size)) == -1) {
+                // 3. address
+                if ((response = read(fd[0], out->address, addr_size)) == -1) {
                     perror("read");
                     exit(1);
                 } else if (response == 0) {
                     fprintf(stdout, "Parent closed the pipe.\n");
-                    if (j == 0) {
-                        free(outputs[j]);
-                    } else if (j > 0) {
-                        for (int addr = 0; addr < j; addr++) {
+                    if (i == 0) {
+                        free(outputs[i]->address);
+                        free(outputs[i]);
+                    } else if (i > 0) {
+                        for (int addr = 0; addr < i; addr++) {
+                            free(outputs[addr]->address);
+                            free(outputs[addr]->script);
                             free(outputs[addr]);
                         }
                     }
                     free(outputs);
                     break;
                 }
-                printf("Received %s from parent.\n", outputs[j]);
+                printf("Received %s from parent.\n", outputs[i]->address);
+
+                // 4. value
+                if ((response = read(fd[0], &(out->value), sizeof(unsigned int)))
+                    == -1) {
+                    perror("read");
+                    exit(1);
+                } else if (response == 0) {
+                    if (i == 0) {
+                        free(outputs[i]->address);
+                        free(outputs[i]);
+                    } else if (i > 0) {
+                        for (int addr = 0; addr < i; addr++) {
+                            free(outputs[addr]->address);
+                            free(outputs[addr]->script);
+                            free(outputs[addr]);
+                        }
+                    }
+                    free(outputs);
+                    break;
+                }
+                printf("Value: %lu sats.\n", outputs[i]->value);
+
+                // 5. script length
+                if ((response = read(fd[0], &script_size, sizeof(int)))== -1) {
+                    perror("read");
+                    exit(1);
+                } else if (response == 0) {
+                    if (i == 0) {
+                        free(outputs[i]->address);
+                        free(outputs[i]);
+                    } else if (i > 0) {
+                        for (int addr = 0; addr < i; addr++) {
+                            free(outputs[addr]->address);
+                            free(outputs[addr]->script);
+                            free(outputs[addr]);
+                        }
+                    }
+                    free(outputs);
+                    break;
+                }
+                out->script = malloc(sizeof(char) * script_size);
+                if (out->script == NULL) {
+                    perror("malloc");
+                    exit(1);
+                }
+                // 6. script
+                if ((response = read(fd[0], out->script, script_size)) == -1) {
+                    perror("read");
+                    exit(1);
+                } else if (response == 0) {
+                    for (int addr = 0; addr < i; addr++) {
+                        free(outputs[addr]->address);
+                        free(outputs[addr]->script);
+                        free(outputs[addr]);
+                    }
+                    free(outputs);
+                    break;
+                }
+                printf("With script: %s.\n", outputs[i]->script);
             }
 
             char *batch; // all the queries combined in a string
@@ -199,14 +214,15 @@ int main() {
             // Check every output against our database
             for (int i = 0; i < ntxOut; i++) {
                 // determine the type of address and build the query
-                if (strncmp(outputs[i], "1", 1) == 0) {
+                if (strncmp(outputs[i]->address, "1", 1) == 0) {
                     query = sqlite3_mprintf(format, "P2PKH", "P2PKH",
-                                                outputs[i]);
-                } else if (strncmp(outputs[i], "3", 1) == 0) {
-                    query = sqlite3_mprintf(format, "P2SH", "P2SH", outputs[i]);
+                                                outputs[i]->address);
+                } else if (strncmp(outputs[i]->address, "3", 1) == 0) {
+                    query = sqlite3_mprintf(format, "P2SH", "P2SH",
+                                            outputs[i]->address);
                 } else {
                     query = sqlite3_mprintf(format, "P2WPKH", "P2WPKH",
-                                                outputs[i]);
+                                                outputs[i]->address);
                 }
 
                 if (query == NULL) {
@@ -252,11 +268,12 @@ int main() {
 
             // free all the addresses we saved
             for (int j = 0; j < ntxOut; j++) {
+                free(outputs[j]->address);
+                free(outputs[j]->script);
                 free(outputs[j]);
             }
 
             free(outputs);
-            memset(child_transaction, '\0', child_tx_size);
         }
 
         // parent process has closed the pipe, begin shutdown
@@ -265,7 +282,6 @@ int main() {
             perror("close");
             exit(1);
         }
-        free(child_transaction);
 
         exit(0);
     } else {
@@ -282,6 +298,29 @@ int main() {
             perror("close");
             exit(1);
         }
+
+        struct bloom address_bloom; // filter of all generated addresses.
+        const char address_filter_file[] = "generated_addresses_filter.b";
+
+        // load the bloom filter
+        if (access((char *) &address_filter_file, F_OK) != -1) {
+            if (bloom_load(&address_bloom, (char *) &address_filter_file) == 0) {
+                printf("Loaded address filter.\n");
+            } else {
+                printf("Failed to load bloom filter.\n");
+                exit(1);
+            }
+        } else {
+            printf("Could not find filter: %s\n", address_filter_file);
+            printf("You have not generated any addresses.\n");
+            exit(1);
+        }
+
+        // some final counts to show the user
+        int total_transactions_checked = 0;
+        int total_addresses_checked = 0;
+        int positive_hit_count = 0;
+
         // Create WebSocket connection with Blockchain.com
         struct lws_context_creation_info info;
         const char *p;
@@ -330,8 +369,8 @@ int main() {
             if (transaction_buf != NULL) {
                 /* 4 cases:
                     1. Partial write & empty buffer
-                    2. Partial write & non-empty buffer (prev msg was partial)
                     3. Complete write & non-empty buffer (...)
+                    2. Partial write & non-empty buffer (prev msg was partial)
                     4. Complete write & empty buffer
                 */
                 if (buffer == NULL) {
@@ -359,6 +398,7 @@ int main() {
                     }
                     strcat(buffer, transaction_buf);
                     buffer_size = buffer_size + transaction_size; // TODO: null terminate?
+                    // buffer[buffer_size] = '\0';
 
                     // we will add the next message to the buffer
                     if (partial_write) {
@@ -369,18 +409,17 @@ int main() {
                         printf("MESSAGE COMPLETED\n");
                     }
                 }
-
                 cur_tx = create_transaction(buffer, buffer_size);
 
                 // reset our buffers now that we saved the data in cur_tx
                 memset(transaction_buf, '\0', transaction_size);
-                transaction_buf = NULL; // otherwise we will enter this if block
                 free(transaction_buf);
+                transaction_buf = NULL; // otherwise we will enter this if block
                 transaction_size = 0;
 
                 memset(buffer, '\0', buffer_size - 1);
-                buffer = NULL;
                 free(buffer);
+                buffer = NULL;
                 buffer_size = 0;
 
                 if (cur_tx == NULL) {
@@ -397,84 +436,91 @@ int main() {
                 // loop over outputs
                 for (int i = 0; i < cur_tx->nOutputs; i++) {
                     // check if we own the output address
-                    if (bloom_check(&address_bloom, cur_tx->outputs[i],
-                                    strlen(cur_tx->outputs[i])) == 1) {
+                    if (bloom_check(&address_bloom, cur_tx->outputs[i]->address,
+                                    strlen(cur_tx->outputs[i]->address)) == 1) {
                         printf("\n********************Positive hit************"\
                                "********\n");
                         positive_hit_count++;
-                        // store positive addresses in linked list
-                        struct node *positive = create_node(cur_tx->outputs[i]);
-                        if (positive == NULL) {
-                            fprintf(stderr, "Couldn't allocate space for Node"\
-                            "\n");
-                            exit(1);
-                        }
-                        add_to_head(positive, &positive_address_head);
+                        cur_tx->outputs[i]->positive = 1; // Will send to child
                         list_size++; // increment number of elements in the LL
                     }
                 }
                 total_transactions_checked++;
                 total_addresses_checked += cur_tx->nOutputs;
                 // write to pipe if we have found potentially spendable addrs
-                if (positive_address_head != NULL) {
+                if (list_size > 0) {
                     printf("May have found spendable outputs. Checking "\
                             "database.\n");
-                    /** Pipe Protocol
-                     * 1. Transaction size: sizeof(int)
-                     * 2. Transaction: size described in previous message
-                     * 3. # of output addresses that will be sent: sizeof(int)
-                     * 4. # of bytes of incoming address (+ '\0'): sizeof(int)
-                     * 5. Address (null terminated): size described in 4.
-                    **/
-
-                    // step 1
-                    if (write(fd[1], &cur_tx->size, sizeof(cur_tx->size)) == -1)
-                    {
-                        perror("write");
-                        fprintf(stderr, "Failed to write transaction size to"\
-                                        " pipe.\n");
-                        exit(1);
-                    }
-                    // step 2
-                    if (write(fd[1], cur_tx->tx, cur_tx->size) == -1) {
-                        perror("write");
-                        fprintf(stderr, "Failed to write transaction to the"\
-                                        " pipe.\n");
-                        exit(1);
-                    }
-                    // step 3
+                    /* Pipe Protocol:
+                        1. Send the number of outputs: (int)
+                        2. Send the size of the current output address: (int)
+                        3. Send the output address: ^size^
+                        4. Send the value: sizeof(unsigned int)
+                        5. Send the size of the script: sizeof(int)
+                        6. Send the script: ^size^
+                    */
+                    // step 1. (new)
                     if (write(fd[1], &list_size, sizeof(list_size)) == -1) {
                         perror("write");
-                        fprintf(stderr, "Failed to write the number of "\
-                                        "addresses to the pipe.\n");
+                        fprintf(stderr, "Failed to write the number of outputs"\
+                                        "to the pipe.\n");
                         exit(1);
                     }
 
-                    struct node *cur = positive_address_head;
-                    // write all the positive addresses to the pipe
-                    while (cur != NULL) {
-                        // step 4
-                        if (write(fd[1], &cur->size, sizeof(cur->size)) == -1) {
-                            perror("write");
-                            fprintf(stderr, "Failed to write the address "\
-                                            "length to the pipe.\n");
-                            exit(1);
-                        }
-                        // step 5
-                        if (write(fd[1], cur->data, cur->size) == -1) {
-                            perror("write");
-                            fprintf(stderr, "Failed to write the address to "\
-                                            "the pipe.\n");
-                            exit(1);
-                        }
+                    // (new)
+                    for (int i = 0; i < cur_tx->nOutputs; i++) {
+                        // write the positive output
+                        if (cur_tx->outputs[i]->positive) {
+                            int addr_size =
+                                strlen(cur_tx->outputs[i]->address) + 1;
 
-                        // free the current node
-                        free(cur->data);
-                        struct node *temp = cur;
-                        cur = cur->next;
-                        free(temp);
+                            // step 2 (new)
+                            if (write(fd[1], &addr_size, sizeof(int)) == -1) {
+                                perror("write");
+                                fprintf(stderr, "Failed to write the address "\
+                                                "length to the pipe.\n");
+                                exit(1);
+                            }
 
-                        list_size--;
+                            // step 3 (new)
+                            if (write(fd[1], cur_tx->outputs[i]->address,
+                                      addr_size) == -1) {
+                                perror("write");
+                                fprintf(stderr, "Failed to write the address "\
+                                                "to the pipe.\n");
+                                exit(1);
+                            }
+
+                            // step 4 (new)
+                            if (write(fd[1], &(cur_tx->outputs[i]->value),
+                                      sizeof(unsigned int)) == -1) {
+                                perror("write");
+                                fprintf(stderr, "Failed to write the output's"\
+                                                " value to the pipe.\n");
+                                exit(1);
+                            }
+
+                            int script_size =
+                                strlen(cur_tx->outputs[i]->script) + 1;
+
+                            // step 5 (new)
+                            if (write(fd[1], &script_size, sizeof(int)) == -1) {
+                                perror("write");
+                                fprintf(stderr, "Failed to write the script "\
+                                                "length to the pipe.\n");
+                                exit(1);
+                            }
+
+                            // step 6 (new)
+                            if (write(fd[1], cur_tx->outputs[i]->script,
+                                      script_size) == -1) {
+                                perror("write");
+                                fprintf(stderr, "Failed to write the script to"\
+                                                " the pipe.\n");
+                                exit(1);
+                            }
+                            list_size--;
+                        }
                     }
                 }
                 free_transaction(cur_tx);
@@ -497,14 +543,13 @@ int main() {
             printf("Received and checked:\n\t%d Transactions\n\t%d Addresses\n",
                     total_transactions_checked, total_addresses_checked);
             printf("Positive hit count: %d\n", positive_hit_count);
-            printf("Finished cleaning up. Exiting.\n");
         } else {
             printf("Something went wrong in the child process. Exiting.\n");
         }
+        bloom_free(&address_bloom);
     }
 
-    bloom_free(&address_bloom);
-    btc_ecc_stop();
+    printf("Finished cleaning up. Exiting.\n");
 
     return 0;
 }

--- a/src/reader.h
+++ b/src/reader.h
@@ -17,11 +17,19 @@ struct node {
     struct node *next; // pointer to next node
 };
 
+/* An output from a transaction. */
+struct output {
+    char *address; // bitcoin address
+    unsigned int value; // value in satoshi's
+    char *script; // the "locking" script
+    int positive; // 1 if positive after bloom filter check, 0 if negative
+};
+
 /* A mempool transaction. */
 struct transaction {
     char *tx; // pointer to the transaction string
     int size; // size of the transaction string
-    char **outputs; // a list of this transaction's output addresses
+    struct output **outputs; // a list of this transaction's outputs
     int nOutputs; // the number of output addresses in this transaction
 };
 
@@ -35,6 +43,10 @@ void add_to_head(struct node *Node, struct node **head);
     Returns 0 on success, 1 on failure.
 */
 int add_private(struct node *Node, char *private);
+
+/*  Creates a new transaction struct consisting of the adddr, val, and script
+    arguments. Returns NULL on failure. */
+struct output* create_output(char *address, unsigned int value, char *script);
 
 /*  Creates a new tranasction struct with the given tx string.
     Returns NULL on failure.

--- a/src/reader_funcs.c
+++ b/src/reader_funcs.c
@@ -168,7 +168,7 @@ struct transaction* create_transaction(char *tx, int size) {
             if (new->outputs[i] == NULL) {
                 perror("malloc");
                 free(new->tx);
-                free(new->outputs)
+                free(new->outputs);
                 free(new);
                 cJSON_Delete(tx_structure);
                 return NULL;

--- a/src/reader_funcs.c
+++ b/src/reader_funcs.c
@@ -110,8 +110,8 @@ struct transaction* create_transaction(char *tx, int size) {
         const char *error_ptr = cJSON_GetErrorPtr();
         if (error_ptr != NULL) {
             fprintf(stderr, "Error, not valid json.\n");
-            free(new);
             free(new->tx);
+            free(new);
             cJSON_Delete(tx_structure);
             return NULL;
         }
@@ -120,8 +120,8 @@ struct transaction* create_transaction(char *tx, int size) {
     x = cJSON_GetObjectItemCaseSensitive(tx_structure, "x");
     if (!cJSON_IsObject(x)) {
         fprintf(stderr, "Couldn't parse transaction.\n");
-        free(new);
         free(new->tx);
+        free(new);
         cJSON_Delete(tx_structure);
         return NULL;
     }
@@ -140,8 +140,8 @@ struct transaction* create_transaction(char *tx, int size) {
     // each element is a pointer to an output struct
     new->outputs = malloc(new->nOutputs * sizeof(struct output*));
     if (new->outputs == NULL) {
-        free(new);
         free(new->tx);
+        free(new);
         perror("malloc");
         return NULL;
     }
@@ -167,8 +167,9 @@ struct transaction* create_transaction(char *tx, int size) {
                                             script->valuestring);
             if (new->outputs[i] == NULL) {
                 perror("malloc");
-                free(new);
                 free(new->tx);
+                free(new->outputs)
+                free(new);
                 cJSON_Delete(tx_structure);
                 return NULL;
             }

--- a/src/reader_funcs.c
+++ b/src/reader_funcs.c
@@ -49,6 +49,38 @@ int add_private(struct node *Node, char *private) {
     return 0;
 }
 
+struct output* create_output(char *address, unsigned int value, char *script) {
+    int addr_size = strlen(address);
+    int script_size = strlen(script);
+
+    struct output *new = malloc(sizeof(struct output));
+    if (new == NULL) {
+        perror("malloc");
+        return NULL;
+    }
+
+    new->address = malloc((addr_size + 1) * sizeof(char));
+    if (new->address == NULL) {
+        perror("malloc");
+        return NULL;
+    }
+    strncpy(new->address, address, addr_size);
+    new->address[addr_size] = '\0';
+
+    new->value = value;
+
+    new->script = malloc((script_size + 1) * sizeof(char));
+    if (new->script == NULL) {
+        perror("malloc");
+        return NULL;
+    }
+    strncpy(new->script, script, script_size);
+    new->script[script_size] = '\0';
+    new->positive = 0;
+
+    return new;
+}
+
 struct transaction* create_transaction(char *tx, int size) {
     struct transaction *new = malloc(sizeof(struct transaction));
     if (new == NULL) {
@@ -59,6 +91,7 @@ struct transaction* create_transaction(char *tx, int size) {
     new->tx = malloc(sizeof(char) * size + 1);
     if (new->tx == NULL) {
         perror("malloc");
+        free(new);
         return NULL;
     }
 
@@ -77,7 +110,8 @@ struct transaction* create_transaction(char *tx, int size) {
         const char *error_ptr = cJSON_GetErrorPtr();
         if (error_ptr != NULL) {
             fprintf(stderr, "Error, not valid json.\n");
-            // fprintf(stderr, "Error before: %s\n", error_ptr);
+            free(new);
+            free(new->tx);
             cJSON_Delete(tx_structure);
             return NULL;
         }
@@ -86,6 +120,8 @@ struct transaction* create_transaction(char *tx, int size) {
     x = cJSON_GetObjectItemCaseSensitive(tx_structure, "x");
     if (!cJSON_IsObject(x)) {
         fprintf(stderr, "Couldn't parse transaction.\n");
+        free(new);
+        free(new->tx);
         cJSON_Delete(tx_structure);
         return NULL;
     }
@@ -101,9 +137,11 @@ struct transaction* create_transaction(char *tx, int size) {
             new->nOutputs++;
         }
     }
-
-    new->outputs = malloc(new->nOutputs * sizeof(char *));
+    // each element is a pointer to an output struct
+    new->outputs = malloc(new->nOutputs * sizeof(struct output*));
     if (new->outputs == NULL) {
+        free(new);
+        free(new->tx);
         perror("malloc");
         return NULL;
     }
@@ -111,22 +149,29 @@ struct transaction* create_transaction(char *tx, int size) {
     // now actually store each output
     int i = 0;
     cJSON_ArrayForEach(output, outputs) {
-        const cJSON *address = NULL; // an outputs address
+        const cJSON *address = NULL; // output address
+        const cJSON *value = NULL; // value in satoshi
+        const cJSON *script = NULL; // the locking script
+
         address = cJSON_GetObjectItemCaseSensitive(output, "addr");
+        value = cJSON_GetObjectItemCaseSensitive(output, "value");
+        script = cJSON_GetObjectItemCaseSensitive(output, "script");
 
-        if (cJSON_IsString(address) && (address->valuestring != NULL)) {
-            // printf("Checking %s\n", address->valuestring);
-            int addr_len = strlen(address->valuestring);
+        // if we find no errors, create the output
+        if (cJSON_IsString(address) && (address->valuestring != NULL) &&
+            cJSON_IsString(script) && (script->valuestring != NULL) &&
+            cJSON_IsNumber(value)) {
 
-            new->outputs[i] = malloc(addr_len * sizeof(char) + 1);
+            new->outputs[i] = create_output(address->valuestring,
+                                            value->valueint,
+                                            script->valuestring);
             if (new->outputs[i] == NULL) {
                 perror("malloc");
+                free(new);
+                free(new->tx);
                 cJSON_Delete(tx_structure);
                 return NULL;
             }
-
-            strcpy(new->outputs[i], address->valuestring);
-            new->outputs[i][addr_len] = '\0';
             i++;
         }
     }
@@ -137,11 +182,12 @@ struct transaction* create_transaction(char *tx, int size) {
 
 void free_transaction(struct transaction *tx) {
     for (int i = 0; i < tx->nOutputs; i++) {
-        free(tx->outputs[i]);
+        free(tx->outputs[i]->address);
+        free(tx->outputs[i]->script);
+        free(tx->outputs[i]); // pointer to output struct
     }
     free(tx->outputs);
     free(tx->tx);
-    tx = NULL;
     free(tx);
 }
 


### PR DESCRIPTION
Sending the child process the transaction is useless, instead, we should be sending an "output" which consists of an `address`, a `value` and the `locking script`.