### PR TITLE
SCAN-19 Store spendable addresses into new table.

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -38,6 +38,7 @@ then
     echo "$db already exists."
 else
     sudo sqlite3 $db < configure.sql
+    sudo chmod 666 $db
 fi
 
 cd ../src/init_download

--- a/configure.sh
+++ b/configure.sh
@@ -19,11 +19,13 @@ sudo rm libbloom.so.2
 
 #compile libwebsockets
 echo "Compiling and installing libwebsockets"
-cd ../libwebsockets
+cd ../../libwebsockets
 mkdir build
 cd build
 cmake ..
 make && sudo make install
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+sudo ldconfig
 cd ..
 
 # create sqlite3 database with keys table

--- a/db/configure.sql
+++ b/db/configure.sql
@@ -16,6 +16,7 @@ CREATE TABLE spendable(
     -- https://github.com/bitcoin/bitcoin/blob/v0.17.0/src/script/script.h#L31-L32
     script VARCHAR(10000),
     value UNSIGNED INTEGER,
+    privkey VARCHAR(32),
     PRIMARY KEY (address, script)
 );
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,7 @@ gen_keys: generate_keys.o key_funcs.o
 # collect and parse mempool transcations
 reader: reader.o reader_funcs.c socket.c
 	${libbtc}/libtool --silent --tag=CC --mode=link gcc ${flags} -static -o $@ \
-	$^ ${libs} cjson/cJSON.c -L/usr/local/libs -lwebsockets
+	$^ ${libs} cjson/cJSON.c -L/usr/local/lib -lwebsockets
 
 %.o: %.c
 	gcc -I${libbtc}/include/btc -I${libbloom} -c $< -o $@

--- a/src/reader.c
+++ b/src/reader.c
@@ -108,7 +108,7 @@ int main() {
                 // increment but don't count null terminator
                 total_addr_size_sum += (addr_size - 1);
 
-                out->address = malloc(sizeof(char) * addr_size);
+                out->address = malloc(addr_size);
                 if (out->address == NULL) {
                     perror("malloc");
                     exit(1);
@@ -174,7 +174,7 @@ int main() {
                     free(outputs);
                     break;
                 }
-                out->script = malloc(sizeof(char) * script_size);
+                out->script = malloc(script_size);
                 if (out->script == NULL) {
                     perror("malloc");
                     exit(1);
@@ -461,7 +461,7 @@ int main() {
                 }
 
                 if (buffer == NULL) {
-                    buffer = malloc(sizeof(char) * (transaction_size + 1));
+                    buffer = malloc(transaction_size + 1);
                     if (buffer == NULL) {
                         perror("malloc");
                         exit(1);
@@ -477,8 +477,7 @@ int main() {
                     }
                 } else if (buffer != NULL) {
                     // buffer has something in it, we want to append to the msg
-                    buffer = realloc(buffer, (buffer_size + transaction_size)
-                                     * sizeof(char));
+                    buffer = realloc(buffer, buffer_size + transaction_size);
                     if (buffer == NULL) {
                         perror("realloc");
                         exit(1);

--- a/src/reader.c
+++ b/src/reader.c
@@ -318,7 +318,7 @@ int main() {
 
                     free(cur->data);
                     free(cur->private);
-                    struct node * temp = cur;
+                    struct node *temp = cur;
                     cur = cur->next;
                     free(temp);
                 }

--- a/src/reader.c
+++ b/src/reader.c
@@ -106,7 +106,7 @@ int main() {
                     break;
                 }
                 // increment but don't count null terminator
-                total_addr_size_sum = total_addr_size_sum + addr_size - 1;
+                total_addr_size_sum += (addr_size - 1);
 
                 out->address = malloc(sizeof(char) * addr_size);
                 if (out->address == NULL) {
@@ -136,8 +136,8 @@ int main() {
                 printf("Received %s from parent.\n", outputs[i]->address);
 
                 // 4. value
-                if ((response = read(fd[0], &(out->value), sizeof(unsigned int)))
-                    == -1) {
+                if ((response = read(fd[0], &(out->value),
+                                     sizeof(unsigned int))) == -1) {
                     perror("read");
                     exit(1);
                 } else if (response == 0) {
@@ -157,7 +157,7 @@ int main() {
                 printf("Value: %lu sats.\n", outputs[i]->value);
 
                 // 5. script length
-                if ((response = read(fd[0], &script_size, sizeof(int)))== -1) {
+                if ((response = read(fd[0], &script_size, sizeof(int))) == -1) {
                     perror("read");
                     exit(1);
                 } else if (response == 0) {
@@ -195,24 +195,27 @@ int main() {
                 printf("With script: %s.\n", outputs[i]->script);
             }
 
-            char *batch; // all the queries combined in a string
-            char *query;
+            char *batch = NULL; // all the queries combined in a string
             // Note: 51 = size of "format" when first 2 "%q"'s are replaced by
             // "P2WPKH" and the final "%q" is empty
             // Will allocate slightly more than enough for the final query.
             int batch_buf_size = ntxOut * 51 + total_addr_size_sum + 1;
-            batch = malloc(batch_buf_size * sizeof(char));
+            batch = malloc(batch_buf_size);
 
             if (batch == NULL) {
                 perror("malloc");
                 exit(1);
+            } else {
+                memset(batch, '\0', batch_buf_size); // clear it just incase.
             }
 
             int address_type;
-            char format[] = "SELECT privkey, %q FROM keys WHERE %q='%q'; ";
+            int batch_size = 0;
+            const char *format = "SELECT privkey, %q FROM keys WHERE %q='%q'; ";
 
             // Check every output against our database
             for (int i = 0; i < ntxOut; i++) {
+                char *query = NULL;
                 // determine the type of address and build the query
                 if (strncmp(outputs[i]->address, "1", 1) == 0) {
                     query = sqlite3_mprintf(format, "P2PKH", "P2PKH",
@@ -229,9 +232,19 @@ int main() {
                     fprintf(stderr, "Failed to build query.");
                     exit(1);
                 }
+                int query_size = strlen(query);
+
+                if (batch_size == 0) {
+                    batch_size += (query_size + 1);
+                } else {
+                    batch_size += query_size;
+                }
+
                 // append the query to batch
-                strcat(batch, query);
+                strncat(batch, query, query_size);
+                batch[batch_size - 1] = '\0';
                 sqlite3_free(query);
+                query = NULL;
             }
 
             // write any returned records to this linked list
@@ -240,20 +253,105 @@ int main() {
             rc = sqlite3_exec(db, batch, callback, &exists, &zErrMsg);
             if (rc != SQLITE_OK) {
                 fprintf(stderr, "SQL error: %s\n", zErrMsg);
+                printf("%s\n", batch);
                 sqlite3_free(zErrMsg);
+                exit(1);
             }
-
+            memset(batch, '\0', batch_buf_size);
             free(batch);
+            batch = NULL;
 
             if (exists != NULL) {
-                // this transaction contains output addresses that we control
+                // Find all instances of this address in this output
+                // Keep track of addresses, since we may get 2+ of the same
+                //      ex. 1 transaction with 4 outputs to 1 address
+                //          We will get that one address 4 times
+                //
+                char *placeholder = "INSERT INTO spendable VALUES"\
+                                    "('%q', '%q', %q, '%q'); ";
+                int batch_size = 0;
+
+                char *start = "BEGIN; ";
+                int start_size = strlen(start);
+                char *end = "COMMIT;";
+
+                batch = malloc(sizeof(char) * start_size + 1);
+
+                if (batch == NULL) {
+                    perror("malloc");
+                    exit(1);
+                }
+
+                strncpy(batch, start, start_size);
+                batch[start_size] = '\0';
+
                 // TODO: we can create a new transaction that spends them.
                 struct node *cur = exists;
                 while (cur != NULL) {
+                    // this algorithm has an awful run time but it doesn't
+                    // matter in this situation, the # of elements is low.
+                    for (int i = 0; i < ntxOut; i++) {
+                        if (strcmp(outputs[i]->address, cur->data) == 0) {
+                            char *query = sqlite3_mprintf(placeholder,
+                                                          outputs[i]->address,
+                                                          outputs[i]->script,
+                                                          outputs[i]->value,
+                                                          cur->private);
+                            if (query == NULL) {
+                                fprintf(stderr, "Failed to build update "\
+                                                "query.");
+                                exit(1);
+                            }
+                            int query_size = strlen(query);
+                            if (batch_size == 0) {
+                                batch = malloc((query_size + 1) * sizeof(char));
+                                if (batch == NULL) {
+                                    perror("malloc");
+                                    exit(1);
+                                }
+                                strncpy(batch, query, query_size);
+                                batch[query_size] = '\0';
+                                batch_size = query_size + 1;
+                            } else {
+                                batch = realloc(batch,
+                                                batch_size + query_size + 1);
+                                if (batch == NULL) {
+                                    perror("realloc");
+                                    exit(1);
+                                }
+                                strncat(batch, query, query_size);
+                                batch_size += (query_size + 1);
+                                batch[batch_size - 1] = '\0';
+                            }
+                            sqlite3_free(query);
+
+                            // Pull the script and value from outputs
+                            // pull the address and private key from the node
+                            // add them to the insert query
+                        }
+                    }
+                    int end_size = strlen(end);
+                    batch = realloc(batch, batch_size + end_size + 1);
+                    if (batch == NULL) {
+                        perror("realloc");
+                        exit(1);
+                    }
+
+                    strncat(batch, end, end_size);
+                    batch[batch_size + end_size] = '\0';
+
                     printf("\nSpendable output discovered!\n");
                     printf("Address: %s\nPrivate Key: %s\n", cur->data,
                             cur->private);
-                    // TODO: do something
+                    printf("Adding to \"Spendable\" table.\n");
+
+                    rc = sqlite3_exec(db, batch, NULL, 0, &zErrMsg);
+                    if (rc != SQLITE_OK) {
+                        fprintf(stderr, "SQL error: %s\n", zErrMsg);
+                        sqlite3_free(zErrMsg);
+                    }
+                    free(batch);
+
                     free(cur->data);
                     free(cur->private);
                     struct node *temp = cur;
@@ -272,7 +370,6 @@ int main() {
                 free(outputs[j]->script);
                 free(outputs[j]);
             }
-
             free(outputs);
         }
 
@@ -304,7 +401,7 @@ int main() {
 
         // load the bloom filter
         if (access((char *) &address_filter_file, F_OK) != -1) {
-            if (bloom_load(&address_bloom, (char *) &address_filter_file) == 0) {
+            if (bloom_load(&address_bloom, (char *) &address_filter_file) == 0){
                 printf("Loaded address filter.\n");
             } else {
                 printf("Failed to load bloom filter.\n");
@@ -332,7 +429,7 @@ int main() {
         memset(&info, 0, sizeof info); /* otherwise uninitialized garbage */
         info.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
         info.port = CONTEXT_PORT_NO_LISTEN; /* we do not run any server */
-        info.protocols = protocols;
+        info.protocols = protocols; // global, see definition in socket.c
 
         /*
         * since we know this lws context is only ever going to be used with
@@ -346,8 +443,9 @@ int main() {
         context = lws_create_context(&info);
         if (!context) {
             lwsl_err("lws init failed\n");
-            return 1;
+            exit(1);
         }
+
         struct transaction *cur_tx; // store transaction details here
         char *buffer = NULL; // a buffer that stores partial writes
         int buffer_size = 0;
@@ -373,61 +471,67 @@ int main() {
                     3. Complete write & non-empty buffer (...)
                     4. Complete write & empty buffer
                 */
+                if (discard) {
+                    memset(buffer, '\0', buffer_size);
+                    free(buffer);
+                    buffer = NULL;
+                    discard = 0;
+                }
+
                 if (buffer == NULL) {
                     buffer = malloc(sizeof(char) * (transaction_size + 1));
                     if (buffer == NULL) {
                         perror("malloc");
                         exit(1);
                     }
-                    strcpy(buffer, transaction_buf);
-                    buffer[transaction_size] = '\0';
+
+                    strncpy(buffer, transaction_buf, transaction_size);
                     buffer_size = transaction_size + 1;
+                    buffer[buffer_size - 1] = '\0';
 
                     // we will add the next message to the buffer
                     if (partial_write) {
-                        printf("Received partial transaction. Waiting for"\
-                               " remaining message.\n");
                         continue;
                     }
                 } else if (buffer != NULL) {
+                    // buffer has something in it, we want to append to the msg
                     buffer = realloc(buffer, (buffer_size + transaction_size)
                                      * sizeof(char));
                     if (buffer == NULL) {
                         perror("realloc");
                         exit(1);
                     }
-                    strcat(buffer, transaction_buf);
-                    buffer_size = buffer_size + transaction_size; // TODO: null terminate?
-                    // buffer[buffer_size] = '\0';
+                    strncat(buffer, transaction_buf, transaction_size);
+                    buffer_size += transaction_size;
+                    buffer[buffer_size - 1] = '\0';
 
                     // we will add the next message to the buffer
                     if (partial_write) {
-                        printf("Received partial transaction. Waiting for"\
-                               " remaining message.\n");
                         continue;
-                    } else {
-                        printf("MESSAGE COMPLETED\n");
                     }
                 }
                 cur_tx = create_transaction(buffer, buffer_size);
 
                 // reset our buffers now that we saved the data in cur_tx
-                memset(transaction_buf, '\0', transaction_size);
-                free(transaction_buf);
-                transaction_buf = NULL; // otherwise we will enter this if block
+                // this is free'd in socket.c
+                memset(transaction_buf, '\0', transaction_size + 1);
                 transaction_size = 0;
 
-                memset(buffer, '\0', buffer_size - 1);
+                memset(buffer, '\0', buffer_size);
                 free(buffer);
                 buffer = NULL;
-                buffer_size = 0;
 
                 if (cur_tx == NULL) {
-                    fprintf(stderr, "Had to discard some partial transactions."\
-                                    "\nThis usually occurs when the order"\
-                                    " of partial reads is lost.\n");
+                    if (buffer_size > 4082) {
+                        fprintf(stderr, "Had to discard some partial "\
+                                        "transactions. \nThis usually occurs "\
+                                        "when the order of partial reads is"\
+                                        " lost.\n");
+                    }
+                    buffer_size = 0;
                     continue;
                 }
+                buffer_size = 0;
 
                 // linked list of addresses that came back as "positive" from BF
                 struct node *positive_address_head = NULL;
@@ -463,7 +567,7 @@ int main() {
                     if (write(fd[1], &list_size, sizeof(list_size)) == -1) {
                         perror("write");
                         fprintf(stderr, "Failed to write the number of outputs"\
-                                        "to the pipe.\n");
+                                        " to the pipe.\n");
                         exit(1);
                     }
 
@@ -520,7 +624,7 @@ int main() {
                 free_transaction(cur_tx);
             }
         }
-
+        free(transaction_buf); // won't be freed in socket.c on user termination
         lws_context_destroy(context);
         lwsl_user("Connection closed.\n");
 

--- a/src/reader.h
+++ b/src/reader.h
@@ -3,6 +3,7 @@
 extern char *transaction_buf;
 extern int transaction_size;
 extern int partial_write; // represents if the current transaction is complete
+extern int discard; // if 1, clear partial read buffer
 
 extern const struct lws_protocols protocols[];
 extern struct lws_context *context;
@@ -27,8 +28,6 @@ struct output {
 
 /* A mempool transaction. */
 struct transaction {
-    char *tx; // pointer to the transaction string
-    int size; // size of the transaction string
     struct output **outputs; // a list of this transaction's outputs
     int nOutputs; // the number of output addresses in this transaction
 };

--- a/src/reader_funcs.c
+++ b/src/reader_funcs.c
@@ -15,7 +15,7 @@ struct node* create_node(char *data) {
     }
     Node->size = strlen(data) + 1; // size includes null terminator
     // fill with data
-    Node->data = malloc(Node->size * sizeof(char));
+    Node->data = malloc(Node->size);
 
     if (Node->data == NULL) {
         perror("malloc");
@@ -40,7 +40,7 @@ void add_to_head(struct node *Node, struct node **head) {
 }
 
 int add_private(struct node *Node, char *private) {
-    Node->private = malloc(strlen(private) * sizeof(char) + 1);
+    Node->private = malloc(strlen(private) + 1);
     if (Node->private == NULL) {
         perror("malloc");
         return 1;
@@ -59,7 +59,7 @@ struct output* create_output(char *address, unsigned int value, char *script) {
         return NULL;
     }
 
-    new->address = malloc((addr_size + 1) * sizeof(char));
+    new->address = malloc(addr_size + 1);
     if (new->address == NULL) {
         perror("malloc");
         return NULL;
@@ -69,7 +69,7 @@ struct output* create_output(char *address, unsigned int value, char *script) {
 
     new->value = value;
 
-    new->script = malloc((script_size + 1) * sizeof(char));
+    new->script = malloc(script_size + 1);
     if (new->script == NULL) {
         perror("malloc");
         return NULL;

--- a/src/socket.c
+++ b/src/socket.c
@@ -11,7 +11,8 @@ static const char *server_address = "ws.blockchain.info", *pro = "wss";
 int subscribed = 0; // becomes 1 when we've subscribed to blockchain service
 char *transaction_buf;
 int transaction_size;
-int partial_write;
+int partial_write = 0;
+int discard = 0;
 
 static int connect_client(void) {
 	struct lws_client_connect_info i;
@@ -89,19 +90,32 @@ callback_tx_client(struct lws *wsi, enum lws_callback_reasons reason,
 
         case LWS_CALLBACK_CLIENT_RECEIVE:
             lwsl_user("Received New Transaction!\n");
+            if (transaction_buf != NULL) {
+                free(transaction_buf);
+                transaction_buf = NULL;
+            }
             transaction_buf = malloc((len + 1) * sizeof(char));
 
             if (transaction_buf == NULL) {
                 perror("malloc");
                 return -1;
+            } else {
+                memset(transaction_buf, '\0', len + 1);
             }
 
             strcpy(transaction_buf, in);
             transaction_buf[len] = '\0';
             transaction_size = len;
 
-            // JSON object ends with }; observed largest tx size is 4082 bytes.
-            if (transaction_buf[len-1] != '}' || transaction_size == 4082) {
+            if (partial_write) {
+                // discard previous read if we got an out of order message
+                if (strstr(transaction_buf, "\"op\"") != NULL) {
+                    discard = 1; // discard previous read
+                }
+            }
+
+            // a partial write
+            if (transaction_buf[len - 1] != '}' || transaction_size == 4082) {
                 partial_write = 1;
             } else {
                 partial_write = 0;

--- a/src/socket.c
+++ b/src/socket.c
@@ -94,7 +94,7 @@ callback_tx_client(struct lws *wsi, enum lws_callback_reasons reason,
                 free(transaction_buf);
                 transaction_buf = NULL;
             }
-            transaction_buf = malloc((len + 1) * sizeof(char));
+            transaction_buf = malloc(len + 1);
 
             if (transaction_buf == NULL) {
                 perror("malloc");


### PR DESCRIPTION
This has a lot of project-wide bug fixes in it. These include

- Patched memory leaks in `./reader`
- Corrected setup issues that lead to compilation failure
- Changed incorrect database table
- Updated pipe protocol to send data that can be used to actually spend outputs
